### PR TITLE
Add exclude third_party to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-slate
+exclude: third_party


### PR DESCRIPTION
Added `exclude: third_party` to _config.yml  to resolve #319, as something in the third_party directory is causing gh_pages to break. The binaries are still exhibit warnings.

